### PR TITLE
Add Codeberg versions of dev and project syncing

### DIFF
--- a/codeberg/Makefile
+++ b/codeberg/Makefile
@@ -1,0 +1,35 @@
+default: devs.json proj-map.json
+all: default all.json
+sync: sync-devs sync-projects
+clean:
+	rm -f devs.ldif devs.json projects.xml all.json proj-map.json
+distclean: clean
+	rm -f proxied-maints.json
+
+TOKEN = ~/.codeberg-token
+
+devs.json: devs.ldif
+	./ldap2devsjson.py $< $@
+
+devs.ldif:
+	ssh dev.gentoo.org "ldapsearch -x '(gentooStatus=active)' -Z uid mail gentooCodebergUser -LLL" > $@
+
+projects.xml:
+	wget -O $@ https://api.gentoo.org/metastructure/projects.xml
+
+proxied-maints.json: $(TOKEN)
+	./update-pr-submitter-db.py $@
+
+all.json: devs.json proxied-maints.json
+	./merge-all.py $^ $@
+
+proj-map.json: projects.xml $(TOKEN)
+	./update-proj-mapping.py $< $@
+
+sync-devs: devs.json $(TOKEN)
+	./sync-devs.py $<
+
+sync-projects: devs.json projects.xml $(TOKEN)
+	./sync-projects.py devs.json projects.xml
+
+.PHONY: default all sync clean distclean

--- a/codeberg/codebergapi.py
+++ b/codeberg/codebergapi.py
@@ -28,6 +28,10 @@ class CodebergAPI:
     def repos_baseurl(self) -> str:
         return f"https://codeberg.org/api/v1/repos/{self.owner}/{self.repo}"
 
+    @property
+    def orgs_baseurl(self) -> str:
+        return f"https://codeberg.org/api/v1/orgs"
+
     def pulls(self) -> Generator[None, dict, None]:
         next_url = f"{self.repos_baseurl}/pulls?state=open"
         while True:
@@ -72,3 +76,15 @@ class CodebergAPI:
 
     def delete_review(self, pr_id: int, review_id: int) -> None:
         self.session.delete(f"{self.repos_baseurl}/pulls/{pr_id}/reviews/{review_id}")
+
+    def teams(self, org: str) -> Generator[None, dict, None]:
+        next_url = f"{self.orgs_baseurl}/{org}/teams"
+        while True:
+            r = self.session.get(next_url)
+            t = r.json()
+            import json; print(json.dumps(t, indent=2))
+            yield from t
+            x = r.links.get("next")
+            if not x:
+                break
+            next_url = x["url"]

--- a/codeberg/codebergapi.py
+++ b/codeberg/codebergapi.py
@@ -1,0 +1,74 @@
+import requests
+from typing import Generator
+
+
+class CodebergAPI:
+    def __init__(self, owner: str, repo: str, token: str):
+        self.owner = owner
+        self.repo = repo
+        self.token = token
+
+    def __enter__(self):
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"token {self.token}",
+                "Content-Type": "application/json",
+            }
+        )
+        self.session.hooks = {
+            "response": lambda r, *args, **kwargs: r.raise_for_status()
+        }
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        self.session.close()
+
+    @property
+    def repos_baseurl(self) -> str:
+        return f"https://codeberg.org/api/v1/repos/{self.owner}/{self.repo}"
+
+    def pulls(self) -> Generator[None, dict, None]:
+        next_url = f"{self.repos_baseurl}/pulls?state=open"
+        while True:
+            r = self.session.get(next_url)
+            yield from r.json()
+            x = r.links.get("next")
+            if not x:
+                break
+            next_url = x["url"]
+
+    def set_pr_title(self, pr_id: int, title: str) -> None:
+        self.session.patch(
+            f"{self.repos_baseurl}/pulls/{pr_id}", json={"title": title}
+        )
+
+    def add_pr_labels(self, pr_id: int, labels: list[int]) -> None:
+        self.session.patch(
+            f"{self.repos_baseurl}/pulls/{pr_id}", json=({"labels": labels})
+        )
+
+    def labels(self) -> list[dict]:
+        return self.session.get(f"{self.repos_baseurl}/labels").json()
+
+    def commits(self, pr_id: int) -> list[dict]:
+        return self.session.get(f"{self.repos_baseurl}/pulls/{pr_id}/commits").json()
+
+    def files(self, pr_id: int) -> list[dict]:
+        return self.session.get(f"{self.repos_baseurl}/pulls/{pr_id}/files").json()
+
+    def get_reviews(self, pr_id: int) -> list[dict]:
+        return self.session.get(f"{self.repos_baseurl}/pulls/{pr_id}/reviews").json()
+
+    def create_review(self, pr_id: int, comment: str) -> None:
+        # Does not appear to be possible to simply post comments
+        # https://codeberg.org/api/swagger#/repository/repoCreatePullReview
+        self.session.post(
+            f"{self.repos_baseurl}/pulls/{pr_id}/reviews",
+            json={
+                "body": comment,
+            },
+        )
+
+    def delete_review(self, pr_id: int, review_id: int) -> None:
+        self.session.delete(f"{self.repos_baseurl}/pulls/{pr_id}/reviews/{review_id}")

--- a/codeberg/codebergapi.py
+++ b/codeberg/codebergapi.py
@@ -46,8 +46,11 @@ class CodebergAPI:
                 break
             next_url = x["url"]
 
-    def pulls(self) -> Generator[None, dict, None]:
-        return self._get_paginated(f"{self.repos_baseurl}/pulls?state=open")
+    def pulls(self, state="open") -> Generator[None, dict, None]:
+        """
+        state must be one of: open, closed, all
+        """
+        return self._get_paginated(f"{self.repos_baseurl}/pulls?state={state}")
 
     def set_pr_title(self, pr_id: int, title: str) -> None:
         self.session.patch(f"{self.repos_baseurl}/pulls/{pr_id}", json={"title": title})
@@ -61,6 +64,7 @@ class CodebergAPI:
         return self.session.get(f"{self.repos_baseurl}/labels").json()
 
     def commits(self, pr_id: int) -> list[dict]:
+        # https://codeberg.org/api/swagger#/repository/repoGetPullRequestCommits
         return self.session.get(f"{self.repos_baseurl}/pulls/{pr_id}/commits").json()
 
     def files(self, pr_id: int) -> list[dict]:

--- a/codeberg/ldap2devsjson.py
+++ b/codeberg/ldap2devsjson.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Create devs.json from LDIF, Codeberg version
+
+import base64
+import json
+import sys
+
+
+def main(list_f="devs.ldif", devs_json="devs.json"):
+    devs = {}
+    with open(list_f) as f:
+        ldif_data = f.read()
+
+    for block in ldif_data.split("\n\n"):
+        if not block.strip():
+            continue
+        mails = set()
+        cbuser = ""
+        for l in block.splitlines():
+            k, v = l.split(":", 1)
+            if v.startswith(":"):
+                # base64
+                v = base64.b64decode(v[1:].strip()).decode()
+            else:
+                v = v.strip()
+
+            if k == "uid":
+                mails.add(v + "@gentoo.org")
+            elif k == "mail":
+                assert "@" in v
+                mails.add(v)
+            elif k == "gentooCodebergUser":
+                cbuser = v
+        assert mails
+        for m in mails:
+            devs[m] = cbuser
+
+    with open(devs_json, "w") as devs_f:
+        json.dump(devs, devs_f, indent=0, sort_keys=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/codeberg/sync-devs.py
+++ b/codeberg/sync-devs.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# vim:fileencoding=utf-8
+# Sync developers team on Codeberg (invite or remove)
+# 2-clause BSD licensed
+
+import json
+import os
+import os.path
+import sys
+
+from codebergapi import CodebergAPI
+
+
+ORG = "gentoo"
+
+
+def main(devs_json="devs.json"):
+    with open(devs_json) as devs_f:
+        devs = json.load(devs_f)
+
+    with open(os.path.expanduser("~/.codeberg-token")) as f:
+        api_token = f.read().strip()
+
+    with CodebergAPI("gentoo", "gentoo", api_token) as cb:
+        for t in cb.teams(ORG):
+            if t["name"] == "developers":
+                break
+        else:
+            raise RuntimeError("Unable to find developers team")
+
+        team_id = t["id"]
+        members = frozenset(m["login"] for m in cb.team_members(team_id))
+        remaining = set(m["login"] for m in cb.org_members(ORG))
+        revmap = dict((v, k) for k, v in devs.items())
+
+        for cbdev, dev in revmap.items():
+            if not cbdev:
+                continue
+            if cbdev in members:
+                remaining.discard(cbdev)
+            else:
+                print(f"INVITE {cbdev} ({dev})")
+                cb.team_add_member(team_id, cbdev)
+        for m in remaining:
+            print(f"REMOVE {m}")
+            cb.org_remove_member(ORG, m)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/codeberg/sync-projects.py
+++ b/codeberg/sync-projects.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# vim:fileencoding=utf-8
+# Sync projects to Codeberg
+# 2-clause BSD licensed
+
+import json
+import os.path
+import sys
+
+import lxml.etree
+from codebergapi import CodebergAPI
+
+
+ORG = "gentoo"
+
+
+def add_members(members, p, xmltree):
+    members += [m.findtext("email").lower() for m in p.findall("member")]
+
+    for subp in p.findall("subproject"):
+        if subp.get("inherit-members") == "1":
+            subp_email = subp.get("ref")
+            for op in xmltree:
+                if op.findtext("email") == subp_email:
+                    add_members(members, op, xmltree)
+
+
+def main(devs_json="devs.json", projects_xml="projects.xml"):
+    with open(devs_json) as devs_f:
+        devs = json.load(devs_f)
+
+    with open(os.path.expanduser("~/.codeberg-token")) as f:
+        api_token = f.read().strip()
+
+    projs_x = lxml.etree.parse(projects_xml)
+    projs = {}
+    for p in projs_x.getroot():
+        projs[p.findtext("email").split("@")[0].lower()] = p
+        projs[p.findtext("name").split("@")[0].lower()] = p
+        projs[p.findtext("url").split(":")[2].lower()] = p
+
+    cb_devs = set(devs.values())
+    rem_projs = set(p for p in projs_x.getroot())
+
+    with CodebergAPI("gentoo", "gentoo", api_token) as cb:
+        for t in cb.teams(ORG):
+            team_id = t["id"]
+            team_name = t["name"]
+            p = projs.get(team_name.lower())
+            if p is None:
+                print(f"{team_name} <-> ?")
+                continue
+            print(f"{team_name} <-> {p}")
+            rem_projs.remove(p)
+            members = []
+            add_members(members, p, projs_x.getroot())
+
+            # all project members mapped to codeberg logins
+            cb_members = set(devs[x] for x in members if x in devs)
+            # all team members as listed in Codeberg
+            team_members = set(u["login"] for u in cb.team_members(team_id))
+
+            # Codeberg members that are not project members
+            extra_cb_members = team_members - cb_members
+
+            # remove extraneous gh team members that do have dev acct
+            # (i.e. most likely left the team)
+            for m in extra_cb_members:
+                if m in cb_devs:
+                    print(f"REMOVE {m}")
+                    cb.team_remove_member(team_id, m)
+                    team_members.discard(m)
+
+            # Project members not listed in team
+            extra_devs = cb_members - team_members
+            for m in extra_devs:
+                print(f"ADD {m}")
+                cb.team_add_member(team_id, m)
+                team_members.add(m)
+
+            # empty now? remove it
+            if not team_members:
+                if next(cb.team_repos(team_id), None):
+                    print("EMPTY TEAM WITH REPOS")
+                else:
+                    print("DELETE TEAM")
+                    cb.org_delete_team(team_id)
+
+    for p in rem_projs:
+        names = [
+            p.findtext("email").split("@")[0],
+            p.findtext("name").lower(),
+            p.findtext("name"),
+            p.findtext("url").split(":")[2].lower(),
+            p.findtext("url").split(":")[2],
+        ]
+        seen = {}
+        names = [seen.setdefault(x, x) for x in names if x not in seen]
+        desc = p.findtext("description")
+        members = []
+        add_members(members, p, projs_x.getroot())
+
+        if not members:
+            if not p.findall("subproject"):
+                print(f"WARN: {names[0]} project has no developers!")
+            else:
+                print(f"NOTE: {names[0]} project purely organizational (no members)")
+            continue
+        cb_members = [devs[m] for m in members if devs.get(m)]
+        if not cb_members:
+            print(f"NOTE: {names[0]} project has no Codeberg users")
+            continue
+
+        print("== NEW PROJECT ==")
+        print("Name:")
+        for i, n in enumerate(names):
+            print(f"{i + 1}) {n}")
+            print(f"Desc: {desc}")
+            print(f"Members: {members}")
+            print(f"Codeberg Members: {cb_members}")
+        while True:
+            resp = input("Proceed? [Y/n/1..%d]" % len(names))
+            if resp.lower() in ["", "y", "n"] + [
+                str(x) for x in range(1, len(names) + 1)
+            ]:
+                break
+            print("Unrecognized reply: %s" % resp)
+        if resp.lower() == "n":
+            continue
+        if resp.lower() in ("", "y"):
+            resp = "1"
+        name = names[int(resp) - 1]
+
+        print(f"CREATE TEAM {name}")
+        t = cb.create_team(ORG, name, desc)
+        team_id = t["id"]
+        for m in cb_members:
+            print(f"ADD {m}")
+            cb.team_add_member(team_id, m)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/codeberg/update-pr-submitter-db.py
+++ b/codeberg/update-pr-submitter-db.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# vim:fileencoding=utf-8
+# Create or update JSON mapping of email->codeberg for pull request
+# submitters
+# 2-clause BSD licensed
+
+import json
+import os
+import os.path
+import sys
+
+from codebergapi import CodebergAPI
+
+
+def main(proxied_maints_json="proxied-maints.json"):
+    maints = {}
+    try:
+        with open(proxied_maints_json) as pm_f:
+            maints = json.load(pm_f)
+    except (OSError, IOError):
+        pass
+
+    with open(os.path.expanduser("~/.codeberg-token")) as f:
+        api_token = f.read().strip()
+
+    with CodebergAPI("gentoo", "gentoo", api_token) as cb:
+        for pr in cb.pulls(state="all"):
+            print(f"PR #{pr['number']:04d}", end="")
+
+            pr_user = pr["user"]["login"]
+            if pr_user not in maints.values():
+                commits = cb.commits(pr["number"])
+                if len(commits) == 0:
+                    continue
+
+                need_confirm = False
+                c1 = commits[0]
+                attributed = c1["committer"]
+                attributed_c = c1["commit"]["committer"]
+
+                if attributed is None:
+                    attributed = c1["author"]
+                    attributed_c = c1["commit"]["author"]
+
+                if attributed is None:
+                    # Codeberg wasn't able to match the committer nor
+                    # author fields to a user name. Prefer suggesting
+                    # the committer email matched to the PR submitter
+                    # login over the author email
+                    print(pr["html_url"])
+                    print(pr["patch_url"])
+                    print(f"PR #{pr['number']}: commit not matched to a user")
+                    attributed = pr["user"]
+                    attributed_c = c1["commit"]["committer"]
+                    print(
+                        f"{attributed_c['email']} ({attributed_c['name']}) -> {attributed['login']} ({attributed['full_name']})"
+                    )
+                    need_confirm = True
+
+                if attributed["login"] != pr_user and c1["author"]["login"] == pr_user:
+                    attributed = c1["author"]
+                    attributed_c = c1["commit"]["author"]
+
+                if attributed["login"] == pr_user:
+                    print(f"\n{attributed_c['email']} -> {attributed['login']}")
+                else:
+                    # In this case: committer, author, and PR
+                    # submitter are all matched to three different
+                    # Codeberg users.
+                    print(pr["html_url"])
+                    print(pr["patch_url"])
+                    print(
+                        "PR submitter matches none of committer or author users. Skipping."
+                    )
+                    continue
+
+                if need_confirm:
+                    escape = False
+                    while True:
+                        resp = input("-> Proceed? [Y/n]")
+                        if resp.lower() == "y" or not resp:
+                            break
+                        elif resp.lower() == "n":
+                            escape = True
+                            break
+                    if escape:
+                        continue
+                maints[attributed_c["email"]] = attributed["login"]
+
+    with open(proxied_maints_json, "w") as pm_f:
+        json.dump(maints, pm_f, indent=2)
+
+    print("")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/codeberg/update-proj-mapping.py
+++ b/codeberg/update-proj-mapping.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# vim:fileencoding=utf-8
+# Write project mapping from e-mails to Codeberg
+# 2-clause BSD licensed
+
+import json
+import os.path
+import sys
+
+import lxml.etree
+from codebergapi import CodebergAPI
+
+
+def main(projects_xml="projects.xml", proj_map_json="proj-map.json"):
+    with open(os.path.expanduser("~/.codeberg-token")) as f:
+        api_token = f.read().strip()
+
+    projs_x = lxml.etree.parse(projects_xml)
+    projs = {}
+    for p in projs_x.getroot():
+        projs[p.findtext("email").split("@")[0].lower()] = p
+        projs[p.findtext("name").split("@")[0].lower()] = p
+        projs[p.findtext("url").split(":")[2].lower()] = p
+
+    proj_map = {}
+    rem_projs = set(p for p in projs_x.getroot())
+
+    with CodebergAPI("gentoo", "gentoo", api_token) as cb:
+        for t in cb.teams("gentoo"):
+            tname = t["name"]
+            p = projs.get(tname.lower())
+            if p is None:
+                print(f"{tname} <-> ?")
+            else:
+                print(f"{tname} <-> {p}")
+                proj_map[p.findtext("email").lower()] = "gentoo/" + tname
+                rem_projs.remove(p)
+
+    for p in rem_projs:
+        print(f"MISSING PROJECT: {p.findtext('email')}")
+
+    with open(proj_map_json, "w") as f:
+        json.dump(proj_map, f, indent=0, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))


### PR DESCRIPTION
So far it's the following scripts

 - codeberg/ldap2devsjson.py - take .ldif input and output a JSON, does not use the Codeberg APIs
 - codeberg/sync-devs.py - add dev codeberg users to gentoo org on codeberg
 - codeberg/sync-projects.py - add/remove teams corresponding to projects, manage the team members
 - codeberg/update-proj-mapping.py - produce a proj-map.json, based on projects.xml and codeberg teams
 - codeberg/update-pr-submitter-db.py - produce a proxy-maints.json mapping (email -> codeberg handle) from PRs

They've been tested with a reduced projects.xml against a test org.