### PR TITLE
Fix some issues with syncing projects on codeberg

### DIFF
--- a/codeberg/sync-projects.py
+++ b/codeberg/sync-projects.py
@@ -43,9 +43,12 @@ def main(devs_json="devs.json", projects_xml="projects.xml"):
     rem_projs = set(p for p in projs_x.getroot())
 
     with CodebergAPI("gentoo", "gentoo", api_token) as cb:
+        teams_to_delete = []
         for t in cb.teams(ORG):
             team_id = t["id"]
             team_name = t["name"]
+            if team_name == "Owners":  # skip special Owners team
+                continue
             p = projs.get(team_name.lower())
             if p is None:
                 print(f"{team_name} <-> ?")
@@ -84,7 +87,10 @@ def main(devs_json="devs.json", projects_xml="projects.xml"):
                     print("EMPTY TEAM WITH REPOS")
                 else:
                     print("DELETE TEAM")
-                    cb.org_delete_team(team_id)
+                    teams_to_delete.append(team_id)
+
+        for team_id in teams_to_delete:
+            cb.org_delete_team(team_id)
 
     for p in rem_projs:
         names = [

--- a/codeberg/sync-projects.py
+++ b/codeberg/sync-projects.py
@@ -97,6 +97,8 @@ def main(devs_json="devs.json", projects_xml="projects.xml"):
         seen = {}
         names = [seen.setdefault(x, x) for x in names if x not in seen]
         desc = p.findtext("description")
+        if len(desc) >= 255:
+            desc = desc[:254] + "…"
         members = []
         add_members(members, p, projs_x.getroot())
 

--- a/codeberg/sync-projects.py
+++ b/codeberg/sync-projects.py
@@ -36,8 +36,8 @@ def main(devs_json="devs.json", projects_xml="projects.xml"):
     projs = {}
     for p in projs_x.getroot():
         projs[p.findtext("email").split("@")[0].lower()] = p
-        projs[p.findtext("name").split("@")[0].lower()] = p
-        projs[p.findtext("url").split(":")[2].lower()] = p
+        projs[p.findtext("name").split("@")[0].replace(" ", "-").lower()] = p
+        projs[p.findtext("url").split(":")[2].replace(" ", "-").lower()] = p
 
     cb_devs = set(devs.values())
     rem_projs = set(p for p in projs_x.getroot())
@@ -95,10 +95,10 @@ def main(devs_json="devs.json", projects_xml="projects.xml"):
     for p in rem_projs:
         names = [
             p.findtext("email").split("@")[0],
-            p.findtext("name").lower(),
-            p.findtext("name"),
-            p.findtext("url").split(":")[2].lower(),
-            p.findtext("url").split(":")[2],
+            p.findtext("name").replace(" ", "-").lower(),
+            p.findtext("name").replace(" ", "-"),
+            p.findtext("url").split(":")[2].replace(" ", "-").lower(),
+            p.findtext("url").split(":")[2].replace(" ", "-"),
         ]
         seen = {}
         names = [seen.setdefault(x, x) for x in names if x not in seen]

--- a/codeberg/sync-projects.py
+++ b/codeberg/sync-projects.py
@@ -56,7 +56,7 @@ def main(devs_json="devs.json", projects_xml="projects.xml"):
             add_members(members, p, projs_x.getroot())
 
             # all project members mapped to codeberg logins
-            cb_members = set(devs[x] for x in members if x in devs)
+            cb_members = set(devs[x] for x in members if devs.get(x))
             # all team members as listed in Codeberg
             team_members = set(u["login"] for u in cb.team_members(team_id))
 


### PR DESCRIPTION
1. The teams API doesn't provide the `Link` header other paginated endpoints do - workaround with `X-Total-Count`
2. Team descriptions are limited to 255 chars
3. Fix subtle bug in setting up `cb_members`